### PR TITLE
TCC file support

### DIFF
--- a/NEWS.TXT
+++ b/NEWS.TXT
@@ -1,6 +1,13 @@
 (For full history, please see the internal git changelog)
 -------------------------------------------------------------------------
 
+Version 0.13:
+
+- TCC tone curve effects have been reverse-engineered and implemented
+  (thanks to lurkmoar)
+
+-------------------------------------------------------------------------
+
 Version 0.12:                                                [2011-05-14]
 
 - User interface polish:

--- a/README.TXT
+++ b/README.TXT
@@ -165,28 +165,9 @@ To build a dmg file for distribution, type:
 
 4) KNOWN ISSUES:
 -------------------------------------------------------------------------
-The interpreter currently lacks the following features:
-
- - TCC shading data used to give character images a certain tint in some
-   scenes. To my knowledge, the file format has not been reverse
-   engineered.
-
 Using rlvm with insani's English translation of Planetarian is currently
 not recommended as the indentation behaviour *will* break in the middle
 of words.
-
-
-5) GETTING INVOLVED
--------------------------------------------------------------------------
-rlvm needs several file formats reverse engineered:
-
-- The TCC file format hasn't been reverse engineered. TCC files (called
-  "tonecurve" files in the GAMEEXE file) are tint definitions that are
-  applied to graphics objects. Tones are applied to objects by loading
-  "filename?[integer]" where [integer] appears to be an index. Any
-  information about this file format would be appreciated.
-
--------------------------------------------------------------------------
 
 ;; Local Variables: **
 ;; fill-column: 72 **

--- a/SConscript
+++ b/SConscript
@@ -178,6 +178,7 @@ librlvm_files = [
   "src/Systems/Base/TextWakuType4.cpp",
   "src/Systems/Base/TextWindow.cpp",
   "src/Systems/Base/TextWindowButton.cpp",
+  "src/Systems/Base/ToneCurve.cpp",
   "src/Systems/Base/VoiceArchive.cpp",
   "src/Systems/Base/VoiceCache.cpp",
   "src/Utilities/Exception.cpp",

--- a/src/Systems/Base/GraphicsSystem.cpp
+++ b/src/Systems/Base/GraphicsSystem.cpp
@@ -158,7 +158,8 @@ GraphicsSystemGlobals::GraphicsSystemGlobals()
   : show_object_1(false), show_object_2(false), show_weather(false),
     skip_animations(0),
     screen_mode(1),
-    cg_table() {
+    cg_table(),
+    tone_curves() {
 }
 
 GraphicsSystemGlobals::GraphicsSystemGlobals(Gameexe& gameexe)
@@ -167,7 +168,8 @@ GraphicsSystemGlobals::GraphicsSystemGlobals(Gameexe& gameexe)
       show_weather(gameexe("INIT_WEATHER_ONOFF_MOD").to_int(0) ? 0 : 1),
       skip_animations(0),
       screen_mode(1),
-      cg_table(gameexe) {
+      cg_table(gameexe),
+      tone_curves(gameexe) {
 }
 
 // -----------------------------------------------------------------------

--- a/src/Systems/Base/GraphicsSystem.hpp
+++ b/src/Systems/Base/GraphicsSystem.hpp
@@ -43,6 +43,7 @@
 #include "Systems/Base/CGMTable.hpp"
 #include "Systems/Base/EventListener.hpp"
 #include "Systems/Base/Rect.hpp"
+#include "Systems/Base/ToneCurve.hpp"
 
 #include "Utilities/LazyArray.hpp"
 
@@ -82,6 +83,9 @@ struct GraphicsSystemGlobals {
 
   // CG Table
   CGMTable cg_table;
+  
+  // tone curve table
+  ToneCurve tone_curves;
 
   /// boost::serialization support
   template<class Archive>
@@ -389,6 +393,9 @@ class GraphicsSystem : public EventListener {
   // Access to the cgtable for the cg* functions.
   CGMTable& cgTable() { return globals_.cg_table; }
 
+  // Access to the tone curve effects file
+  ToneCurve& toneCurve() { return globals_.tone_curves; }
+  
   // We have a cache of HIK scripts. This is done so we can load HIKScripts
   // outside of loops.
   void PreloadHIKScript(System& system,

--- a/src/Systems/Base/Surface.hpp
+++ b/src/Systems/Base/Surface.hpp
@@ -29,6 +29,7 @@
 #define SRC_SYSTEMS_BASE_SURFACE_HPP_
 
 #include "Systems/Base/Rect.hpp"
+#include "Systems/Base/ToneCurve.hpp"
 
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/shared_ptr.hpp>
@@ -65,6 +66,9 @@ class Surface : public boost::enable_shared_from_this<Surface> {
 
   // Fills |area| with |colour|.
   virtual void fill(const RGBAColour& colour, const Rect& area) = 0;
+  
+  // Apply the given tone curve effect to the surface
+  virtual void toneCurve(const ToneCurveRGBMap effect, const Rect& area) = 0;
 
   // Inverts each color of the surface (like a photo negative).
   virtual void invert(const Rect& area) = 0;

--- a/src/Systems/Base/ToneCurve.cpp
+++ b/src/Systems/Base/ToneCurve.cpp
@@ -1,0 +1,129 @@
+// -*- Mode: C++; tab-width:2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi:tw=80:et:ts=2:sts=2
+//
+// -----------------------------------------------------------------------
+//
+// This file is part of RLVM, a RealLive virtual machine clone.
+//
+// -----------------------------------------------------------------------
+//
+// Copyright (C) 2008 Elliot Glaysher
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// -----------------------------------------------------------------------
+
+#include "Systems/Base/ToneCurve.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <boost/scoped_array.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+#include "MachineBase/Memory.hpp"
+#include "MachineBase/RLMachine.hpp"
+#include "Utilities/Exception.hpp"
+#include "Utilities/File.hpp"
+#include "libReallive/gameexe.h"
+#include "libReallive/intmemref.h"
+#include "xclannad/endian.hpp"
+#include "xclannad/file.h"
+
+#include <iostream>
+
+using namespace std;
+using boost::scoped_array;
+
+namespace fs = boost::filesystem;
+
+ToneCurve::ToneCurve() {
+}
+
+ToneCurve::ToneCurve(Gameexe& gameexe) {
+  GameexeInterpretObject filename_key = gameexe("TONECURVE_FILENAME");
+  if (!filename_key.exists()) {
+    // It is perfectly valid not to have a tone curve key. All operations in this
+    // class become noops.
+    return;
+  }
+
+  string tonecurve = filename_key.to_string("");
+  if (tonecurve == "") {
+    // It is perfectly valid not to have a tone curve. All operations in this
+    // class become noops.
+    return;
+  }
+
+  fs::path basename = gameexe("__GAMEPATH").to_string();
+  fs::path filename = correctPathCase(basename / "dat" / tonecurve);
+
+  int size;
+  scoped_array<char> data;
+  if (loadFileData(filename, data, size)) {
+    ostringstream oss;
+    oss << "Could not read contents of file \"" << filename << "\".";
+    throw rlvm::Exception(oss.str());
+  }
+
+  if (read_little_endian_int(data.get()) != 1000) {
+    ostringstream oss;
+    oss << "File '" << filename << "' is not a TCC file!";
+    throw rlvm::Exception(oss.str());
+  }
+
+  effect_count_ = read_little_endian_int(data.get() + 4);
+  tcc_info_.clear();
+  int offset = 0xFE8;
+  for (int i = 0; i < effect_count_; i++) {
+    ToneCurveColorMap red;
+    ToneCurveColorMap green;
+    ToneCurveColorMap blue;
+    ToneCurveRGBMap rgb;	
+    unsigned char* ptr = &red[0];
+    memcpy(ptr, data.get() + offset, 256);
+    offset += 256;
+    ptr = &green[0];
+    memcpy(ptr, data.get() + offset, 256);
+    offset += 256;
+    ptr = &blue[0];
+    memcpy(ptr, data.get() + offset, 256);
+    offset += 256;
+    rgb[0] = red;
+    rgb[1] = green;
+    rgb[2] = blue;
+    tcc_info_.push_back(rgb);
+    offset += 0x40;
+  }
+}
+
+int ToneCurve::getEffectCount() const {
+  return effect_count_;
+}
+
+ToneCurveRGBMap ToneCurve::getEffect(int index) {
+  if(index >= getEffectCount() || index < 0) {
+    ostringstream oss;
+    oss << "Requested tone curve index " << index << " exceeds the amount of effects in the tone curve file.";
+    throw rlvm::Exception(oss.str());    		
+  }
+  
+  return tcc_info_[index];
+}
+
+ToneCurve::~ToneCurve() {
+  tcc_info_.clear();
+}

--- a/src/Systems/Base/ToneCurve.hpp
+++ b/src/Systems/Base/ToneCurve.hpp
@@ -1,0 +1,73 @@
+// -*- Mode: C++; tab-width:2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi:tw=80:et:ts=2:sts=2
+//
+// -----------------------------------------------------------------------
+//
+// This file is part of RLVM, a RealLive virtual machine clone.
+//
+// -----------------------------------------------------------------------
+//
+// Copyright (C) 2008 Elliot Glaysher 
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// -----------------------------------------------------------------------
+
+#ifndef SRC_SYSTEMS_BASE_TONECURVE_HPP_
+#define SRC_SYSTEMS_BASE_TONECURVE_HPP_
+
+#include <boost/array.hpp>
+#include <vector>
+
+class Gameexe;
+class RLMachine;
+
+typedef boost::array<unsigned char, 256> ToneCurveColorMap;
+typedef boost::array<ToneCurveColorMap, 3> ToneCurveRGBMap;
+typedef std::vector<ToneCurveRGBMap> ToneCurveEffects;
+
+// Manages tone curve effects
+//
+// The tcc file is a set of mapping between R, G, and B color values and their
+// corresponding values after the tone curve is applied, where tcc_effect[2][1][200]
+// is the corresponding green value for a green value of 200 in the original image
+// when the tone curve with the "index" of 2 is applied.
+// ToneCurve class is responsible for loading the tcc data and providing an
+// interface for applying tone curve effects.
+class ToneCurve {
+ public:
+  // Initializes an empty tone curve set (for games that don't use this feature).
+  ToneCurve();
+
+  // Initializes the CG table with the TCC data file specified in the
+  // #TONECURVE_FILENAME gameexe key.
+  explicit ToneCurve(Gameexe& gameexe);
+  ~ToneCurve();
+
+  // Returns the total number of tone curve effects available in the tone curve file
+  int getEffectCount() const;
+
+  // Return the effect at the given index (used by Surface in toneCurve()).  The effects are indexed from 0 to effect_count - 1
+  ToneCurveRGBMap getEffect(int index);
+
+ private:
+
+  // Array of tone curve effects
+  ToneCurveEffects tcc_info_;
+  int effect_count_;
+
+};  // end of class ToneCurve
+
+#endif  // SRC_SYSTEMS_BASE_TONECURVE_HPP_

--- a/src/Systems/SDL/SDLRenderToTextureSurface.cpp
+++ b/src/Systems/SDL/SDLRenderToTextureSurface.cpp
@@ -103,21 +103,25 @@ void SDLRenderToTextureSurface::fill(const RGBAColour& colour,
 }
 
 void SDLRenderToTextureSurface::invert(const Rect& rect) {
-  throw SystemError("Unsupported operation fill on SDLRenderToTextureSurface!");
+  throw SystemError("Unsupported operation invert on SDLRenderToTextureSurface!");
 }
 
 void SDLRenderToTextureSurface::mono(const Rect& rect) {
-  throw SystemError("Unsupported operation fill on SDLRenderToTextureSurface!");
+  throw SystemError("Unsupported operation mono on SDLRenderToTextureSurface!");
+}
+
+void SDLRenderToTextureSurface::toneCurve(const ToneCurveRGBMap effect, const Rect& rect) {
+  throw SystemError("Unsupported operation toneCurve on SDLRenderToTextureSurface!");
 }
 
 void SDLRenderToTextureSurface::applyColour(
     const RGBColour& colour, const Rect& area) {
-  throw SystemError("Unsupported operation fill on SDLRenderToTextureSurface!");
+  throw SystemError("Unsupported operation applyColour on SDLRenderToTextureSurface!");
 }
 
 void SDLRenderToTextureSurface::getDCPixel(const Point& pos,
                                            int& r, int& g, int& b) const {
-  throw SystemError("Unsupported operation fill on SDLRenderToTextureSurface!");
+  throw SystemError("Unsupported operation getDCPixel on SDLRenderToTextureSurface!");
 }
 
 Size SDLRenderToTextureSurface::size() const {

--- a/src/Systems/SDL/SDLRenderToTextureSurface.hpp
+++ b/src/Systems/SDL/SDLRenderToTextureSurface.hpp
@@ -70,6 +70,7 @@ class SDLRenderToTextureSurface : public Surface,
   virtual void fill(const RGBAColour& colour, const Rect& rect);
   virtual void invert(const Rect& rect);
   virtual void mono(const Rect& area);
+  virtual void toneCurve(const ToneCurveRGBMap effect, const Rect& rect);
   virtual void applyColour(const RGBColour& colour, const Rect& area);
 
   virtual void getDCPixel(const Point& pos, int& r, int& g, int& b) const;

--- a/src/Systems/SDL/SDLSurface.hpp
+++ b/src/Systems/SDL/SDLSurface.hpp
@@ -36,6 +36,7 @@
 #include "base/notification_observer.h"
 #include "base/notification_registrar.h"
 #include "Systems/Base/Surface.hpp"
+#include "Systems/Base/ToneCurve.hpp"
 
 struct SDL_Surface;
 class Texture;
@@ -211,6 +212,7 @@ class SDLSurface : public Surface,
   virtual void fill(const RGBAColour& colour, const Rect& area);
   virtual void invert(const Rect& rect);
   virtual void mono(const Rect& area);
+  virtual void toneCurve(const ToneCurveRGBMap effect, const Rect& area);
   virtual void applyColour(const RGBColour& colour, const Rect& area);
 
   SDL_Surface* surface() { return surface_; }

--- a/test/TestSystem/MockSurface.hpp
+++ b/test/TestSystem/MockSurface.hpp
@@ -64,6 +64,7 @@ class MockSurface : public Surface {
   MOCK_METHOD1(fill, void(const RGBAColour&));
   MOCK_METHOD2(fill, void(const RGBAColour&, const Rect&));
   MOCK_METHOD1(invert, void(const Rect&));
+  MOCK_METHOD2(toneCurve, void(const ToneCurveRGBMap effect, const Rect& area));
   MOCK_METHOD1(mono, void(const Rect&));
   MOCK_METHOD2(applyColour, void(const RGBColour&, const Rect&));
 


### PR DESCRIPTION
I believe I have implemented support for tone curve effects read from TCC files. Hope this works :) - unfortunately I only had access to 64-bit Linux and Memorial Edition or newer games for testing, though I did manually extract and apply data from TCC files from other games to random images in a test program and the results seemed like what they should be.
