### PR TITLE
Tomoyo After DT00.DLL skeleton code

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -185,6 +185,7 @@ librlvm_files = [
   "src/Systems/Base/TextWakuType4.cpp",
   "src/Systems/Base/TextWindow.cpp",
   "src/Systems/Base/TextWindowButton.cpp",
+  "src/Systems/Base/TomoyoAfterDT00DLL.cpp",
   "src/Systems/Base/ToneCurve.cpp",
   "src/Systems/Base/VoiceArchive.cpp",
   "src/Systems/Base/VoiceCache.cpp",

--- a/src/MachineBase/RealLiveDLL.cpp
+++ b/src/MachineBase/RealLiveDLL.cpp
@@ -28,6 +28,7 @@
 
 #include "Systems/Base/LittleBustersEF00DLL.hpp"
 #include "Systems/Base/LittleBustersPT00DLL.hpp"
+#include "Systems/Base/TomoyoAfterDT00DLL.hpp"
 #include "Systems/Base/RlBabelDLL.hpp"
 #include "Utilities/Exception.hpp"
 
@@ -48,6 +49,8 @@ RealLiveDLL* RealLiveDLL::BuildDLLNamed(RLMachine& machine,
     return new LittleBustersEF00DLL;
   } else if (name == "PT00") {
     return new LittleBustersPT00DLL;
+  } else if (name == "DT00") {
+    return new TomoyoAfterDT00DLL;
   } else {
     ostringstream oss;
     oss << "Unsupported DLL interface " << name;

--- a/src/Systems/Base/TomoyoAfterDT00DLL.cpp
+++ b/src/Systems/Base/TomoyoAfterDT00DLL.cpp
@@ -1,0 +1,48 @@
+// -*- Mode: C++; tab-width:2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi:tw=80:et:ts=2:sts=2
+//
+// -----------------------------------------------------------------------
+//
+// This file is part of RLVM, a RealLive virtual machine clone.
+//
+// -----------------------------------------------------------------------
+//
+// Copyright (C) 2013 Elliot Glaysher
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// -----------------------------------------------------------------------
+
+#include "Systems/Base/TomoyoAfterDT00DLL.hpp"
+
+#include <iostream>
+using namespace std;
+
+TomoyoAfterDT00DLL::TomoyoAfterDT00DLL() {
+  cerr << "WARNING: Tomoyo After: Dungeons & Takafumis is implemented in a DLL"
+       << " and hasn't been reverse engineered yet." << endl;
+}
+
+TomoyoAfterDT00DLL::~TomoyoAfterDT00DLL() {}
+
+int TomoyoAfterDT00DLL::callDLL(RLMachine& machine, int func, int arg1,
+                                  int arg2, int arg3, int arg4) {
+  // Perform no spew.
+  return 0;
+}
+
+const std::string& TomoyoAfterDT00DLL::name() const {
+  static std::string n("DT00");
+  return n;
+}

--- a/src/Systems/Base/TomoyoAfterDT00DLL.hpp
+++ b/src/Systems/Base/TomoyoAfterDT00DLL.hpp
@@ -1,0 +1,47 @@
+// -*- Mode: C++; tab-width:2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi:tw=80:et:ts=2:sts=2
+//
+// -----------------------------------------------------------------------
+//
+// This file is part of RLVM, a RealLive virtual machine clone.
+//
+// -----------------------------------------------------------------------
+//
+// Copyright (C) 2013 Elliot Glaysher
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// -----------------------------------------------------------------------
+
+#ifndef SRC_SYSTEMS_BASE_TOMOYOAFTERDT00DLL_HPP_
+#define SRC_SYSTEMS_BASE_TOMOYOAFTERDT00DLL_HPP_
+
+#include "MachineBase/RealLiveDLL.hpp"
+
+#include <string>
+
+// This file exists to suppress spew. Comment once at the beginning that the
+// RPG minigame DLL hasn't been reverse engineered and then ignore calls.
+class TomoyoAfterDT00DLL : public RealLiveDLL {
+ public:
+  TomoyoAfterDT00DLL();
+  virtual ~TomoyoAfterDT00DLL();
+
+  // Overridden from RealLiveDLL:
+  virtual int callDLL(RLMachine& machine, int func, int arg1, int arg2,
+                      int arg3, int arg4);
+  virtual const std::string& name() const;
+};
+
+#endif  // SRC_SYSTEMS_BASE_TOMOYOAFTERDT00DLL_HPP_


### PR DESCRIPTION
This prevents callDll error spew, and gives us a skeleton to build on
in case someone ever figures out what this DLL is doing.
