### PR TITLE
Fix compiling with libpng >= 1.5.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -21,7 +21,7 @@ AddOption('--fullstatic', action='store_true',
 env = Environment(
   tools = ["default", "rlvm"],
 
-  LIBS = ["z"],
+  LIBS = ["z", "png"],
 
   LOCAL_LIBS = [],
 


### PR DESCRIPTION
Use png_get functions instead of making direct access to the members of
png_struct and info_struct.
Provide functions to emulate missing png_get when compiling with versions under 1.5.0.

Successfully compiled on my openSUSE tumbleweed.
Testing with clannad full voice[original] and everything's good so far.