### PR TITLE
Unbreak build with Boost 1.69

### DIFF
--- a/src/systems/base/gan_graphics_object_data.cc
+++ b/src/systems/base/gan_graphics_object_data.cc
@@ -36,6 +36,7 @@
 
 #include <boost/serialization/export.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <iostream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
After boostorg/serialization@af46ac2da3e9 (post-Beta1) build fails. See [error log](https://ptpb.pw/8Rh1).

```c++
src/systems/base/gan_graphics_object_data.cc:56:12: error: no member named 'cerr' in namespace 'std'
using std::cerr;
      ~~~~~^
```
