### PR TITLE
When ％ or ＊ is not followed by Ａ-Ｚ treat the character literally.

### DIFF
--- a/src/systems/base/text_system.cc
+++ b/src/systems/base/text_system.cc
@@ -880,7 +880,10 @@ void parseNames(const Memory& memory,
         // Try to read a second character. We don't care if it fails.
         ReadFullwidthLatinLetter(cur, strindex);
       } else {
-        throw rlvm::Exception("Malformed name construct in bytecode!");
+        // It was "as-is" character, not a name reference.
+        output += (char)0x81;
+        output += type;
+        continue;
       }
 
       int index = Memory::ConvertLetterIndexToInt(strindex);


### PR DESCRIPTION
For instance CLANNAD FV has

  "【％Ｂ】「よぅし、特別に、全部１０％引きにしてやる」"

among 20 phrases where (some) "％" are literal.