### PR TITLE
Some fixes for Little Busters russian patch

### DIFF
--- a/src/systems/base/event_system.h
+++ b/src/systems/base/event_system.h
@@ -187,8 +187,8 @@ class EventSystem {
   // Helper function that verifies input
   void CheckLayerAndCounter(int layer, int counter);
 
-  std::unique_ptr<FrameCounter> frame_counters_[255][2];
-  RLTimer timers_[255][2];
+  std::unique_ptr<FrameCounter> frame_counters_[2][255];
+  RLTimer timers_[2][255];
 
   EventListeners event_listeners_;
 

--- a/src/systems/base/rlbabel_dll.cc
+++ b/src/systems/base/rlbabel_dll.cc
@@ -523,7 +523,8 @@ int RlBabelDLL::SetCurrentWindowName(StringReferenceIterator buffer) {
   // Haeleth's implementation of SetCurrentWindowName in rlBabel goes through
   // some monstrous hacks, including temporarily rewriting the bytecode at the
   // instruction pointer. I *think* I can get away with a simple:
-  GetWindow(-1)->SetNameWithoutDisplay(*buffer);
+  GetWindow(-1)->SetNameWithoutDisplay(
+      cp932toUTF8(*buffer, machine_.GetTextEncoding()));
   return 1;
 }
 


### PR DESCRIPTION
I'm trying to resolve a couple of problems here.
- When a text window has a name and it's not in English, the text window appears empty and a UTF-8 decode error message appears in the console. This happens because the code that sets the window name lacks cp932->utf8 conversion. This is obviously by accident, fixed that.
- Invalid line breaks: <details>![](https://github.com/user-attachments/assets/e16a0fd2-ce1e-4240-805c-e454a72e4f0f)</details>
There are two different parts of code responsible for line breaks. One of them is in rlBabel, another one thinks our font is monospaced and all russian characters are double width. For that reason it makes line breaks in inappropriate places because it thinks we're over the width (which is not true). rlBabel tries to fix the situation as the next character is being printed by setting the appropriate X coordinate but it's already too late. Disabling non-rlBabel line breaks seems to solve the problem so I've added a command line option for that. (Don't wanna just erase the code because it seems too dangerous and I can't test it on anything else for now.)