### PR TITLE
Fix Infinite Loop in LBEX Scene 8695 Parsing

### DIFF
--- a/src/libreallive/bytecode.cc
+++ b/src/libreallive/bytecode.cc
@@ -897,6 +897,10 @@ GosubWithElement::GosubWithElement(const char* src, ConstructionData& cdata)
 
     while (*src != ')') {
       int expr = NextData(src);
+      if(expr == 0){
+        src++;
+        continue;
+      }
       repr_size += expr;
       params.emplace_back(src, expr);
       src += expr;

--- a/src/libreallive/bytecode.cc
+++ b/src/libreallive/bytecode.cc
@@ -118,6 +118,11 @@ CommandElement* BuildFunctionElement(const char* stream) {
     const char* end = ptr + 1;
     while (*end != ')') {
       const size_t len = NextData(end);
+      if (len <= 0) {
+        std::ostringstream os;
+        os << "at BuildFunctionElement: invalid token " << *end;
+        throw Error(os.str());
+      }
       params.emplace_back(end, len);
       end += len;
     }
@@ -897,9 +902,10 @@ GosubWithElement::GosubWithElement(const char* src, ConstructionData& cdata)
 
     while (*src != ')') {
       int expr = NextData(src);
-      if(expr == 0){
-        src++;
-        continue;
+      if (expr <= 0) {
+        std::ostringstream os;
+        os << "at GosubWithElement constructor: invalid token " << *src;
+        throw Error(os.str());
       }
       repr_size += expr;
       params.emplace_back(src, expr);

--- a/src/libreallive/expression.cc
+++ b/src/libreallive/expression.cc
@@ -148,6 +148,11 @@ size_t NextString(const char* src) {
       ++end;
   }
 
+  auto IsTag = [](const char* src) {
+    return *src == 'a' && (*(src + 1) == 0 || *(src + 1) == 1);
+  };
+  if (end > src && IsTag(end - 1))
+    --end;
   return end - src;
 }
 


### PR DESCRIPTION
At the end of the Little Busters EX combat mini-game, an infinite loop is occurred while parsing seen 8695. The problem occurs in the `GosubWithElement` constructor where the `src` pointer doesn't advance when `NextData` returns zero-length expressions. This behavior was encountered at seen 8695, address 0x886.

Ensuring that the `src` pointer progresses after each call to `NextData` regardless of the expression length returned should prevent the infinite loop. While I didn't look into the exact intended behavior of the original bytecode, this workaround seems to solve the problem with no disruptions revealed.