### PR TITLE
Fix heap overflow in NWA decoder

### DIFF
--- a/src/modules/module_sys_save.cc
+++ b/src/modules/module_sys_save.cc
@@ -28,6 +28,7 @@
 #include "modules/module_sys_save.h"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>

--- a/src/systems/base/system.cc
+++ b/src/systems/base/system.cc
@@ -28,7 +28,7 @@
 #include "systems/base/system.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 

--- a/vendor/xclannad/nwatowav.cc
+++ b/vendor/xclannad/nwatowav.cc
@@ -569,7 +569,7 @@ int NWAData::Decode(FILE* in, char* data, int& skip_count) {
 	if (skip_count) {
 		int skip_c = skip_count * channels * (bps/8);
 		retsize -= skip_c;
-		memmove(data, data+skip_c, skip_c);
+		memmove(data, data+skip_c, retsize);
 		skip_count = 0;
 	}
 	curblock++;


### PR DESCRIPTION
Wrong amount of bytes were moved when skipping samples during decoding, possibly leading to random crashes.

Also fixed some compilation errors when using newer Boost versions.